### PR TITLE
pytest deprecation warning : MarkInfo objects are deprecated

### DIFF
--- a/pytest_arraydiff/plugin.py
+++ b/pytest_arraydiff/plugin.py
@@ -212,7 +212,7 @@ class ArrayComparison(object):
 
     def pytest_runtest_setup(self, item):
 
-        compare = item.keywords.get('array_compare')
+        compare = item.get_closest_marker('array_compare')
 
         if compare is None:
             return

--- a/pytest_arraydiff/plugin.py
+++ b/pytest_arraydiff/plugin.py
@@ -36,6 +36,7 @@ import abc
 import shutil
 import tempfile
 import warnings
+from distutils.version import StrictVersion
 
 import six
 from six.moves.urllib.request import urlopen
@@ -212,7 +213,11 @@ class ArrayComparison(object):
 
     def pytest_runtest_setup(self, item):
 
-        compare = item.get_closest_marker('array_compare')
+        if StrictVersion(pytest.__version__) < StrictVersion("3.6"):
+            compare = item.get_marker('array_compare')
+        else:
+            compare = item.get_closest_marker('array_compare')
+        
 
         if compare is None:
             return


### PR DESCRIPTION
MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly.
Tried to change this according to their suggestion : Please use node.get_closest_marker(name) or node.iter_markers(name).
https://docs.pytest.org/en/latest/mark.html#updating-code
Test failing report for astropy/regions  : https://travis-ci.org/astropy/regions/jobs/387743813