### PR TITLE
Remove astropy dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,9 @@ setup_requires =
 install_requires =
     pytest>=4.6
     numpy
+
+[options.extras_require]
+test =
     astropy
 
 [options.entry_points]

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,8 @@ deps =
     pytest61: pytest==6.1.*
     pytest62: pytest==6.2.*
     pytestdev: git+https://github.com/pytest-dev/pytest#egg=pytest
-
+extras =
+    test
 commands =
     pip freeze
     pytest {toxinidir}/tests {posargs}


### PR DESCRIPTION
This removal breaks the circular dependency

astropy ---> pytest-astropy ---> pytest-arraydiff

which may be problematic when upgrading or so. It also eases the use of pytest-arraydiff in non-astropy environments. Astropy is only needed to compare FITS files.
The plugin itself is already prepared (it imports astropy only when needed).

Relevant Debian bug: [Debian#1003238](https://bugs.debian.org/1003238)