### PR TITLE
Test inside `pytest_runtest_call` hook

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,8 @@ markers =
     array_compare: for functions using array comparison
 filterwarnings =
     error
+    # Can be removed when min Python is >=3.8
+    ignore:distutils Version classes are deprecated
 
 [flake8]
 max-line-length = 150

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,8 @@ testpaths = tests
 xfail_strict = true
 markers =
     array_compare: for functions using array comparison
+filterwarnings =
+    error
 
 [flake8]
 max-line-length = 150


### PR DESCRIPTION
This changes the plugin's pytest integration to be the same as pytest-mpl, which is able to handle intercepting returned values for further testing.

Fix #35