### PR TITLE
Fix compatibility with pytest-run-parallel and add free-threaded CI jobs

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -18,10 +18,7 @@ jobs:
     with:
       envs: |
         - linux: codestyle
-        - windows: py39-test-pytestoldest
-        - linux: py39-test-pytest53
-        - macos: py39-test-pytest60
-        - windows: py39-test-pytest61
+        - windows: py39-test-pytest62
         - linux: py310-test-pytest62
         - macos: py310-test-pytest70
         - windows: py310-test-pytest71
@@ -31,8 +28,8 @@ jobs:
         - linux: py313-test-pytest83
         - linux: py313-test-pytest90
         - linux: py313-test-parallel
-        - linux: py313t-test
-        - linux: py313t-test-parallel
+        - linux: py314t-test
+        - linux: py314t-test-parallel
         - linux: py313-test-devdeps
   publish:
     needs: tests

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -30,6 +30,9 @@ jobs:
         - windows: py312-test-pytest74
         - linux: py313-test-pytest83
         - linux: py313-test-pytest90
+        - linux: py313-test-parallel
+        - linux: py313t-test
+        - linux: py313t-test-parallel
         - linux: py313-test-devdeps
   publish:
     needs: tests

--- a/pytest_arraydiff/plugin.py
+++ b/pytest_arraydiff/plugin.py
@@ -240,12 +240,18 @@ def wrap_array_interceptor(plugin, item):
     # Only intercept array on marked array tests
     if item.get_closest_marker('array_compare') is not None:
 
+        # Guard against wrapping more than once (e.g. when pytest-run-parallel
+        # runs the same item multiple times).
+        if getattr(item.obj, '_arraydiff_wrapped', False):
+            return
+
         # Use the full test name as a key to ensure correct array is being retrieved
         test_name = generate_test_name(item)
 
         def array_interceptor(store, obj):
             def wrapper(*args, **kwargs):
                 store.return_value[test_name] = obj(*args, **kwargs)
+            wrapper._arraydiff_wrapped = True
             return wrapper
 
         item.obj = array_interceptor(plugin, item.obj)
@@ -259,6 +265,10 @@ class ArrayComparison:
         self.generate_dir = generate_dir
         self.default_format = default_format
         self.return_value = {}
+
+    def pytest_collection_modifyitems(self, items):
+        for item in items:
+            wrap_array_interceptor(self, item)
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_call(self, item):
@@ -298,8 +308,6 @@ class ArrayComparison:
 
         baseline_remote = reference_dir.startswith('http')
 
-        # Run test and get array object
-        wrap_array_interceptor(self, item)
         yield
         test_name = generate_test_name(item)
         if test_name not in self.return_value:
@@ -372,11 +380,11 @@ class ArrayInterceptor:
         self.config = config
         self.return_value = {}
 
-    @pytest.hookimpl(hookwrapper=True)
-    def pytest_runtest_call(self, item):
-
-        if item.get_closest_marker('array_compare') is not None:
+    def pytest_collection_modifyitems(self, items):
+        for item in items:
             wrap_array_interceptor(self, item)
 
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_call(self, item):
         yield
         return

--- a/pytest_arraydiff/plugin.py
+++ b/pytest_arraydiff/plugin.py
@@ -383,8 +383,3 @@ class ArrayInterceptor:
     def pytest_collection_modifyitems(self, items):
         for item in items:
             wrap_array_interceptor(self, item)
-
-    @pytest.hookimpl(hookwrapper=True)
-    def pytest_runtest_call(self, item):
-        yield
-        return

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,13 +32,10 @@ python_requires = >=3.9
 setup_requires =
     setuptools_scm
 install_requires =
-    pytest>=5.0
+    pytest>=6.2
     numpy
 
-# tables limitation is until 3.9.3 is out as that supports ARM OSX, and
-# tables wheels are not yet available for free-threaded CPython.  Since
-# PEP 508 has no marker for that, tables is split into its own extra and
-# tox only installs it on the non-free-threaded envs.
+# tables limitation is until 3.9.3 is out as that supports ARM OSX.
 [options.extras_require]
 test =
     astropy
@@ -51,7 +48,7 @@ pytest11 =
     pytest_arraydiff = pytest_arraydiff.plugin
 
 [tool:pytest]
-minversion = 5.0
+minversion = 6.2
 testpaths = tests
 xfail_strict = true
 markers =

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,11 +35,15 @@ install_requires =
     pytest>=5.0
     numpy
 
-# tables limitation is until 3.9.3 is out as that supports ARM OSX.
+# tables limitation is until 3.9.3 is out as that supports ARM OSX, and
+# tables wheels are not yet available for free-threaded CPython.  Since
+# PEP 508 has no marker for that, tables is split into its own extra and
+# tox only installs it on the non-free-threaded envs.
 [options.extras_require]
 test =
     astropy
     pandas
+test_hdf5 =
     tables;platform_machine!='arm64'
 
 [options.entry_points]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["pytester"]

--- a/tests/test_pytest_arraydiff.py
+++ b/tests/test_pytest_arraydiff.py
@@ -193,12 +193,9 @@ def test_parallel_iterations():
     """Regression test: arraydiff should work with pytest-run-parallel."""
     pytest.importorskip('pytest_run_parallel')
 
-    tmpdir = tempfile.mkdtemp()
-    test_file = os.path.join(tmpdir, 'test.py')
-    with open(test_file, 'w') as f:
-        f.write(TEST_PARALLEL)
-
-    gen_dir = os.path.join(tmpdir, 'reference')
+    test_file = tmp_path / 'test.py'
+    test_file.write_test(TEST_PARALLEL)
+    gen_dir = tmp_path / 'reference'
 
     # Generate the reference file first
     code = subprocess.call(

--- a/tests/test_pytest_arraydiff.py
+++ b/tests/test_pytest_arraydiff.py
@@ -189,25 +189,20 @@ def test_parallel():
 """
 
 
-def test_parallel_iterations():
+def test_parallel_iterations(pytester):
     """Regression test: arraydiff should work with pytest-run-parallel."""
     pytest.importorskip('pytest_run_parallel')
 
-    test_file = tmp_path / 'test.py'
-    test_file.write_test(TEST_PARALLEL)
-    gen_dir = tmp_path / 'reference'
+    pytester.makepyfile(test_parallel=TEST_PARALLEL)
+    gen_dir = pytester.path / 'reference'
 
     # Generate the reference file first
-    code = subprocess.call(
-        ['pytest', f'--arraydiff-generate-path={gen_dir}', test_file],
-        timeout=30,
-    )
-    assert code == 0
+    result = pytester.runpytest_subprocess(f'--arraydiff-generate-path={gen_dir}')
+    assert result.ret == 0
 
     # Now run with --arraydiff and multiple iterations
-    code = subprocess.call(
-        ['pytest', '--arraydiff', f'--arraydiff-reference-path={gen_dir}',
-         '--parallel-threads=2', '--iterations=3', test_file],
-        timeout=30,
+    result = pytester.runpytest_subprocess(
+        '--arraydiff', f'--arraydiff-reference-path={gen_dir}',
+        '--parallel-threads=2', '--iterations=3',
     )
-    assert code == 0
+    assert result.ret == 0

--- a/tests/test_pytest_arraydiff.py
+++ b/tests/test_pytest_arraydiff.py
@@ -177,3 +177,40 @@ class TestSingleReferenceClass:
 
 def test_nofile():
     pass
+
+
+TEST_PARALLEL = """
+import pytest
+import numpy as np
+from astropy.io import fits
+@pytest.mark.array_compare(file_format='fits')
+def test_parallel():
+    return fits.PrimaryHDU(np.arange(3 * 5).reshape((3, 5)).astype(np.int64))
+"""
+
+
+def test_parallel_iterations():
+    """Regression test: arraydiff should work with pytest-run-parallel."""
+    pytest.importorskip('pytest_run_parallel')
+
+    tmpdir = tempfile.mkdtemp()
+    test_file = os.path.join(tmpdir, 'test.py')
+    with open(test_file, 'w') as f:
+        f.write(TEST_PARALLEL)
+
+    gen_dir = os.path.join(tmpdir, 'reference')
+
+    # Generate the reference file first
+    code = subprocess.call(
+        ['pytest', f'--arraydiff-generate-path={gen_dir}', test_file],
+        timeout=30,
+    )
+    assert code == 0
+
+    # Now run with --arraydiff and multiple iterations
+    code = subprocess.call(
+        ['pytest', '--arraydiff', f'--arraydiff-reference-path={gen_dir}',
+         '--parallel-threads=2', '--iterations=3', test_file],
+        timeout=30,
+    )
+    assert code == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311,312,313,314}-test{,-pytestoldest,-pytest52,-pytest53,-pytest60,-pytest61,-pytest62,-pytest70,-pytest71,-pytest72,-pytest73,-pytest74,-devdeps}
+    py{39,310,311,312,313,314}-test{,-pytest62,-pytest70,-pytest71,-pytest72,-pytest73,-pytest74,-devdeps}
     py{313t,314t}-test{,-parallel}
     codestyle
 isolated_build = true
@@ -12,11 +12,6 @@ setenv =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 description = run tests
 deps =
-    pytestoldest: pytest==5.0.0
-    pytest52: pytest==5.2.*
-    pytest53: pytest==5.3.*
-    pytest60: pytest==6.0.*
-    pytest61: pytest==6.1.*
     pytest62: pytest==6.2.*
     pytest70: pytest==7.0.*
     pytest71: pytest==7.1.*

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,11 @@ deps =
     devdeps: astropy>=0.0.dev0
 extras =
     test
+    # tables (PyTables) is needed for the pandas/HDF5 file_format, but
+    # has no free-threaded wheels and its sdist requires libhdf5-dev,
+    # which CI does not install.  Skip the HDF5 extras on free-threaded
+    # envs.
+    !py313t-!py314t: test_hdf5
 commands =
     # Force numpy-dev after something in the stack downgrades it
     devdeps: python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy

--- a/tox.ini
+++ b/tox.ini
@@ -36,8 +36,7 @@ extras =
     test
     # tables (PyTables) is needed for the pandas/HDF5 file_format, but
     # has no free-threaded wheels and its sdist requires libhdf5-dev,
-    # which CI does not install.  Skip the HDF5 extras on free-threaded
-    # envs.
+    # which CI does not install. Only run these test on GIL-enabled builds.
     !py313t-!py314t: test_hdf5
 commands =
     # Force numpy-dev after something in the stack downgrades it

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 [tox]
 envlist =
     py{39,310,311,312,313,314}-test{,-pytestoldest,-pytest52,-pytest53,-pytest60,-pytest61,-pytest62,-pytest70,-pytest71,-pytest72,-pytest73,-pytest74,-devdeps}
+    py{313t,314t}-test{,-parallel}
     codestyle
 isolated_build = true
 
 [testenv]
 changedir = .tmp/{envname}
 setenv =
+    py313t,py314t: PYTHON_GIL = 0
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 description = run tests
 deps =
@@ -24,6 +26,7 @@ deps =
     pytest80: pytest==8.0.*
     pytest83: pytest==8.3.*
     pytest90: pytest==9.0.*
+    parallel: pytest-run-parallel
     devdeps: git+https://github.com/pytest-dev/pytest#egg=pytest
     devdeps: numpy>=0.0.dev0
     devdeps: pandas>=0.0.dev0


### PR DESCRIPTION
Without this fix, we can't run tests with pytest-run-parallel if those tests rely on pytest-arraydiff (which is used e.g. in reproject):

```
hook_name = 'pytest_runtest_call', hook_impl = <HookImpl plugin_name='140326316292304', plugin=<pytest_arraydiff.plugin.ArrayComparison object at 0x7fa0443c38d0>>
e = AttributeError("'NoneType' object has no attribute 'writeto'")

    def _warn_teardown_exception(
        hook_name: str, hook_impl: HookImpl, e: BaseException
    ) -> None:
        msg = "A plugin raised an exception during an old-style hookwrapper teardown.\n"
        msg += f"Plugin: {hook_impl.plugin_name}, Hook: {hook_name}\n"
        msg += f"{type(e).__name__}: {e}\n"
        msg += "For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning"  # noqa: E501
>       warnings.warn(PluggyTeardownRaisedWarning(msg), stacklevel=6)
E       pluggy.PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown.
E       Plugin: 140326316292304, Hook: pytest_runtest_call
E       AttributeError: 'NoneType' object has no attribute 'writeto'
E       For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning

../../../python/dev/lib/python3.11/site-packages/pluggy/_callers.py:73: PluggyTeardownRaisedWarning
```

The fix here ensures we don't wrap the tests multiple times, and make sure we always pass output values through.

(Note: I pushed this to an upstream branch by mistake as this repo used to be under my user - will fix it for future)