### PR TITLE
Fix interference with pytest-run-parallel detection of known thread-unsafe calls

### DIFF
--- a/pytest_arraydiff/plugin.py
+++ b/pytest_arraydiff/plugin.py
@@ -266,10 +266,6 @@ class ArrayComparison:
         self.default_format = default_format
         self.return_value = {}
 
-    def pytest_collection_modifyitems(self, items):
-        for item in items:
-            wrap_array_interceptor(self, item)
-
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_call(self, item):
 
@@ -308,6 +304,8 @@ class ArrayComparison:
 
         baseline_remote = reference_dir.startswith('http')
 
+        # Run test and get array object
+        wrap_array_interceptor(self, item)
         yield
         test_name = generate_test_name(item)
         if test_name not in self.return_value:
@@ -380,6 +378,11 @@ class ArrayInterceptor:
         self.config = config
         self.return_value = {}
 
-    def pytest_collection_modifyitems(self, items):
-        for item in items:
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_call(self, item):
+
+        if item.get_closest_marker('array_compare') is not None:
             wrap_array_interceptor(self, item)
+
+        yield
+        return


### PR DESCRIPTION
Update: This PR (unsurprisingly) breaks the test in #63, so for the time being consider this to be an issue report.

---

This PR partially reverts #63 because the switch to wrapping tests during the collection phase apparently interferes with the pytest-run-parallel's automatic detection of known thread-unsafe calls (e.g., `warnings.catch_warnings()` on non-freethreaded Python).

### Example test file
```python
import warnings
import pytest
import numpy as np

@pytest.mark.array_compare
def test_simple():
    with warnings.catch_warnings():
        pass
    return np.arange(3 * 5).reshape((3, 5))
```

### Before this PR
Using the not-freethreaded build of Python 3.14.5:
```
C:\Users\ayshih\Downloads>pytest -vv --parallel-threads=auto --arraydiff test_simple.py
============================================== test session starts ==============================================
platform win32 -- Python 3.14.5, pytest-9.0.3, pluggy-1.6.0 -- C:\Users\ayshih\miniforge3\envs\pad\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\ayshih\Downloads
plugins: arraydiff-0.7.1.dev2+g56809c5be, run-parallel-0.9.1
collected 1 item
Collected 1 items to run in parallel

test_simple.py::test_simple <- ..\OneDrive\code\pytest-arraydiff\pytest_arraydiff\plugin.py PARALLEL PASSED [100%]
****************************************** pytest-run-parallel report *******************************************
All tests were run in parallel! 🎉

=============================================== 1 passed in 0.31s ===============================================
```
pytest-run-parallel runs the test in parallel even though it shouldn't.  Of course, there's no harm in running this simple test in parallel, but sunpy's parallel-threads-on-non-freethreaded-Python CI run is now suddenly failing after the release of pytest-arraydiff 0.7.0.

### After this PR
```
C:\Users\ayshih\Downloads>pytest -vv --parallel-threads=auto --arraydiff test_simple.py
============================================== test session starts ==============================================
platform win32 -- Python 3.14.5, pytest-9.0.3, pluggy-1.6.0 -- C:\Users\ayshih\miniforge3\envs\pad\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\ayshih\Downloads
plugins: arraydiff-0.7.1.dev3+g8c0a5a686, run-parallel-0.9.1
collected 1 item
Collected 0 items to run in parallel

test_simple.py::test_simple PASSED [thread-unsafe]: calls thread-unsafe function: warnings.catch_warnings  [100%]
****************************************** pytest-run-parallel report *******************************************
1 test was not run in parallel because of use of thread-unsafe functionality, to list the tests that were not run in parallel, re-run while setting PYTEST_RUN_PARALLEL_VERBOSE=1 in your shell environment

=============================================== 1 passed in 0.36s ===============================================
```
This behavior matches the behavior prior to #63.

I certainly don't fully understand the implications of this reversion, and perhaps pytest-run-parallel ought to be able to detect through the new approach to wrapping.